### PR TITLE
Feature to skip the BOM from deserialization

### DIFF
--- a/src/NServiceBus.Json/JsonConfigurationExtensions.cs
+++ b/src/NServiceBus.Json/JsonConfigurationExtensions.cs
@@ -86,5 +86,25 @@ namespace NServiceBus
         {
             return settings.GetOrDefault<string>("NServiceBus.SystemJson.ContentTypeKey");
         }
+
+        /// <summary>
+        /// Configures to skip the Byte Order Marker (BOM) before deserialization.
+        /// </summary>
+        /// <remarks>
+        /// Defaults to <see cref="ContentTypes.Json"/>.
+        /// This setting is required when this serializer needs to co-exist with other json serializers.
+        /// </remarks>
+        /// <param name="config">The <see cref="SerializationExtensions{T}"/> instance.</param>
+        /// <param name="skipBom">Skip Byte Order Marker (BOM) from input</param>
+        public static void SkipBom(this SerializationExtensions<SystemJsonSerializer> config, bool skipBom)
+        {
+            var settings = config.GetSettings();
+            settings.Set("NServiceBus.SystemJson.SkipBom", skipBom);
+        }
+
+        internal static bool GetSkipBom(this ReadOnlySettings settings)
+        {
+            return settings.GetOrDefault<bool>("NServiceBus.SystemJson.SkipBom");
+        }
     }
 }

--- a/src/NServiceBus.Json/JsonConfigurationExtensions.cs
+++ b/src/NServiceBus.Json/JsonConfigurationExtensions.cs
@@ -90,10 +90,6 @@ namespace NServiceBus
         /// <summary>
         /// Configures to skip the Byte Order Marker (BOM) before deserialization.
         /// </summary>
-        /// <remarks>
-        /// Defaults to <see cref="ContentTypes.Json"/>.
-        /// This setting is required when this serializer needs to co-exist with other json serializers.
-        /// </remarks>
         /// <param name="config">The <see cref="SerializationExtensions{T}"/> instance.</param>
         /// <param name="skipBom">Skip Byte Order Marker (BOM) from input</param>
         public static void SkipBom(this SerializationExtensions<SystemJsonSerializer> config, bool skipBom)

--- a/src/NServiceBus.Json/SystemJsonSerializer.cs
+++ b/src/NServiceBus.Json/SystemJsonSerializer.cs
@@ -23,7 +23,8 @@ namespace NServiceBus.Json
                 var readerOptions = settings.GetReaderOptions();
                 var writerOptions = settings.GetWriterOptions();
                 var contentTypeKey = settings.GetContentTypeKey();
-                return new JsonMessageSerializer(options, writerOptions, readerOptions, contentTypeKey);
+                var skipBom = settings.GetSkipBom();
+                return new JsonMessageSerializer(options, writerOptions, readerOptions, contentTypeKey, skipBom);
             };
         }
     }


### PR DESCRIPTION
#### Description

When a sending NServiceBus Endpoint is using NewtonSoft as Json Serializer and the Receiver Enpoint is using this library then it's impossible to read messages.


#### The solution

Found a way to skip the BOM original code found on [https://docs.microsoft.com/en-us/dotnet/standard/serialization/system-text-json-how-to#use-utf8jsonreader](url)