### PR TITLE
Add obsoletion to source and link to NServiceBus upgrade guide

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -7,6 +7,8 @@ To change this file edit the source file and then run MarkdownSnippets.
 
 # <img src="/src/icon.png" height="30px"> NServiceBus.Json
 
+> **NOTE**: Message serialization using System.Text.Json has been merged into NServiceBus version 8.1.0 and above. This package will not be updated. See the [NServiceBus upgrade guide](https://docs.particular.net/nservicebus/upgrades/community-system-json) for instructions on how to upgrade to the built-in serializer.
+
 [![Build status](https://ci.appveyor.com/api/projects/status/5djip8pld58ykwpi/branch/main?svg=true)](https://ci.appveyor.com/project/SimonCropp/nservicebus-Json)
 [![NuGet Status](https://img.shields.io/nuget/v/NServiceBus.Json.svg)](https://www.nuget.org/packages/NServiceBus.Json/)
 
@@ -46,7 +48,7 @@ Thanks to all the backing developers. Support this project by [becoming a patron
 ```cs
 endpointConfiguration.UseSerialization<SystemJsonSerializer>();
 ```
-<sup><a href='/src/Sample/Program.cs#L9-L11' title='Snippet source file'>snippet source</a> | <a href='#snippet-usage' title='Start of snippet'>anchor</a></sup>
+<sup><a href='/src/Sample/Program.cs#L11-L13' title='Snippet source file'>snippet source</a> | <a href='#snippet-usage' title='Start of snippet'>anchor</a></sup>
 <!-- endSnippet -->
 
 

--- a/readme.source.md
+++ b/readme.source.md
@@ -1,5 +1,7 @@
 # <img src="/src/icon.png" height="30px"> NServiceBus.Json
 
+> **NOTE**: Message serialization using System.Text.Json has been merged into NServiceBus version 8.1.0 and above. This package will not be updated. See the [NServiceBus upgrade guide](https://docs.particular.net/nservicebus/upgrades/community-system-json) for instructions on how to upgrade to the built-in serializer.
+
 [![Build status](https://ci.appveyor.com/api/projects/status/5djip8pld58ykwpi/branch/main?svg=true)](https://ci.appveyor.com/project/SimonCropp/nservicebus-Json)
 [![NuGet Status](https://img.shields.io/nuget/v/NServiceBus.Json.svg)](https://www.nuget.org/packages/NServiceBus.Json/)
 

--- a/src/NServiceBus.Json/JsonConfigurationExtensions.cs
+++ b/src/NServiceBus.Json/JsonConfigurationExtensions.cs
@@ -1,3 +1,5 @@
+#pragma warning disable CS0618 // Type or member is obsolete
+
 using System.Text.Json;
 using NServiceBus.Configuration.AdvancedExtensibility;
 using NServiceBus.Json;

--- a/src/NServiceBus.Json/SystemJsonSerializer.cs
+++ b/src/NServiceBus.Json/SystemJsonSerializer.cs
@@ -7,6 +7,7 @@ namespace NServiceBus.Json;
 /// <summary>
 /// Defines the capabilities of the System.Text.Json serializer
 /// </summary>
+[Obsolete("The NServiceBus.Json package has been incorporated into NServiceBus version 8.1.0. This package will not be updated. See https://docs.particular.net/nservicebus/upgrades/community-system-json to upgrade.", false)]
 public class SystemJsonSerializer :
     SerializationDefinition
 {

--- a/src/Sample/Program.cs
+++ b/src/Sample/Program.cs
@@ -1,4 +1,6 @@
-﻿using NServiceBus;
+#pragma warning disable CS0618 // Type or member is obsolete
+
+using NServiceBus;
 using NServiceBus.Json;
 
 class Program

--- a/src/Tests/IntegrationTest.cs
+++ b/src/Tests/IntegrationTest.cs
@@ -1,3 +1,5 @@
+#pragma warning disable CS0618 // Type or member is obsolete
+
 using Microsoft.Extensions.DependencyInjection;
 using NServiceBus;
 using NServiceBus.Json;


### PR DESCRIPTION
#### Description

Obsoletes the serializer and points to the NServiceBus upgrade guide.

#### The solution

* What was done
  * Adds an obsoletion message to the `SystemJsonSerializer` class (as warning) as the main entry point into the API.
  * Adds pragmas to other files to ignore the obsoletion warning
  * Links to the NServiceBus upgrade guide both in the obsolete message and as a notice at the top of the README.
* Alternatives considered
  * Considered obsolete as error, but that would be a SemVer break. That would probably include hollowing out the API with NotImplementedExceptions. I can still do that if you prefer. I figure people may still want to use this for NServiceBus 8.0.0 and it may be advantageous for someone to update all packages and then slowly move endpoint-by-endpoint.


#### Todos

 * [x] Related issues
 * [x] Tests
 * [x] Documentation